### PR TITLE
Remove extra header padding

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -31,10 +31,6 @@ html {
   border-color: $light-brown;
 }
 
-#main-outlet {
-  padding-top: 72px;
-}
-
 div.ac-wrap,
 .select-kit.combo-box .select-kit-header,
 .search-container .search-advanced-sidebar .date-picker,


### PR DESCRIPTION
Too much padding is the result of the header change in Discourse core (`fixed` to `sticky`, see: https://github.com/discourse/discourse/pull/10781)

Before / after / try.discourse.org to compare

<img width="266" alt="Screen Shot 2020-12-29 at 20 35 54" src="https://user-images.githubusercontent.com/66961/103310020-e5cbb280-4a16-11eb-977c-2e8b80b9e7bc.png"> <img width="266" alt="Screen Shot 2020-12-29 at 20 36 03" src="https://user-images.githubusercontent.com/66961/103310016-e3695880-4a16-11eb-8272-77fb629f795b.png"> <img width="266" alt="Screen Shot 2020-12-29 at 20 36 10" src="https://user-images.githubusercontent.com/66961/103309995-d9dff080-4a16-11eb-8727-60813778f4d8.png">
